### PR TITLE
fix(test): StringYamlConfigurationProvider implements the modern File…

### DIFF
--- a/file-configuration-storage-test/src/main/java/com/jellyrekt/storage/configuration/file/yaml/StringYamlConfigurationProvider.java
+++ b/file-configuration-storage-test/src/main/java/com/jellyrekt/storage/configuration/file/yaml/StringYamlConfigurationProvider.java
@@ -6,7 +6,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
-import com.jellyrekt.storage.fileconfiguration.FileConfigurationProvider;
+import com.jellyrekt.storage.configuration.file.FileConfigurationProvider;
 
 /**
  * A {@link FileConfigurationProvider} backed by a YAML string rather than a file.


### PR DESCRIPTION
…ConfigurationProvider (not the deprecated one)